### PR TITLE
Github actions for build/test, release candidate, and publishing pipelines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:   
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: |
+            npm i
+            npm i -g vsce
+    - run: |
+        npm run compile
+        vsce package
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i
+      - run: npm run tslint
+      - run: npm run compile
+      - run: xvfb-run -a npm test
+        if: runner.os == 'Linux'
+      - run: npm test
+        if: runner.os != 'Linux'

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -1,0 +1,59 @@
+name: rc-release
+
+on:
+  workflow_dispatch:
+  push:
+    tags: # only checks for -rc tags
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: 12.x
+    - run: |
+        npm i
+        npm i -g vsce
+    - run: |
+        npm run compile
+        vsce package
+  
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i
+      - run: npm run tslint
+      - run: npm run compile
+      - run: xvfb-run -a npm test
+        if: runner.os == 'Linux'
+      - run: npm test
+        if: runner.os != 'Linux'
+  release:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: 12.x
+    - run: |
+        npm i
+        npm i -g vsce
+        node scripts/genAiKey.js
+        npm run compile
+        vsce package
+    - uses: actions/upload-artifact@v2
+      with:
+        path: '*.vsix'

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,0 +1,70 @@
+
+name: release
+
+on:
+  push:
+    tags: # only checks for prod tags
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '!**[a-zA-Z]+'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: 12.x
+    - run: |
+        npm i
+        npm i -g vsce
+    - run: |
+        npm run compile
+        vsce package
+  
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i
+      - run: npm run tslint
+      - run: node scripts/genAiKey.js
+      - run: npm run compile
+      - run: xvfb-run -a npm test
+        if: runner.os == 'Linux'
+      - run: npm test
+        if: runner.os != 'Linux'
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: true
+
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: '*.vsix'
+
+    - name: Publish to VSCode Marketplace
+      run: vsce publish -p ${{ secrets.VSCE_TOKEN }} --packagePath *.vsix
+    


### PR DESCRIPTION
Adds the following pipelines as github actions:
- **Build and test** as a CI action (pull requests and pushes)
- **Release-RC** as a workflow action to test packaged builds
- **Release-Prod** as a workflow action to release tagged/version builds and publish them to the extension marketplace.