### PR TITLE
Update testing matrices for github CI actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        node-version: [12.x]
+        os: [ubuntu-latest, windows-latest]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -32,8 +32,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        node-version: [12.x]
+        os: [ubuntu-latest, windows-latest]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.4


### PR DESCRIPTION
Updates the github CI actions pipeline to bump node versions and test on linux and windows instead of linux and mac